### PR TITLE
Tiny improvements

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,7 +84,7 @@
       Harmlos, oder?
       Jede Form würde sich in einer gemischten Nachbarschaft wohlfühlen.
       Ihr kleines Vorurteil kann eine größere Gesellschaft sicherlich nicht beeinflussen?
-      Naja...
+      Naja &hellip;
 		</p>
 		<div class="instruction">
 			Verschiebe unglückliche Formen bis keine mehr unglücklich ist:<br>
@@ -101,7 +101,7 @@
 	<!-- CHAPTER -->
 	<div class="chapter">
 		<p>
-			Und... unsere Form-Gesellschaft ist auf einmal extrem gespalten. Mist!
+			Und &hellip; unsere Form-Gesellschaft ist auf einmal extrem gespalten. Mist!
 		</p>
 		<p>
       Manchmal wird eine Nachbarschaft eben „viereckig“
@@ -159,7 +159,7 @@
 		<p>
       Beobachte wie die Trennung zunimmt, wenn die Vorurteile auf über 33% erhöht werden.
       Was, wenn die Grenze bei 50% wäre?
-      Es erscheint vernünftig, wenn eine Form es bevorzugt nicht in der Minderheit zu sein...
+      Es erscheint vernünftig, wenn eine Form es bevorzugt nicht in der Minderheit zu sein &hellip;
 		</p>
 		
 		<br>
@@ -201,7 +201,7 @@
 			WOW! Obwohl jedes Polygon mit bis zu 90% ihm gleichen Nachbarn zufrieden wäre,
       vermischen sich alle.
       Lass uns das im größeren Maßstab betrachten,
-      wenn wir die Menge von Vorurteil und Vorlieben für alle Formen ändern.
+      wenn wir das Ausmaß an Vorurteilen und Vorlieben für alle Formen ändern.
 		</p>
 		<div class="instruction">
 			Die Welt startet getrennt. Was passiert, wenn die Formen nur ein wenig Vielfalt verlangen?
@@ -243,7 +243,7 @@
 		<iframe playable src="play/mini/mini_cooperate.html" width="810" height="290" scrolling="no" style="margin:0 auto;display:block" embedded></iframe>
 		
 		<p>
-      Ganz alleine loszuziehen kann einsam machen...
+      Ganz alleine loszuziehen kann einsam machen &hellip;
       aber gemeinsam, Schritt für Schritt, schaffen wir es.
 		</p>
 
@@ -266,7 +266,7 @@
 			<b>1. Kleine individuelle Vorurteile &rarr; große gesellschaftliche Vorurteile.</b>
 			<br>
 			<!--Micromotives, macrobehaviour...-->
-      Wenn eine Gesellschaft „formistisch“ ist, sagen man nicht, dass die <i>Individuen</i> in ihr Formisten sind.
+      Wenn eine Gesellschaft „formistisch“ ist, sagt man nicht, dass die <i>Individuen</i> in ihr Formisten sind.
       Persönlich greift man dich nicht an.
 		</p>
 		<p>

--- a/play/mini/mini_cooperate.html
+++ b/play/mini/mini_cooperate.html
@@ -12,7 +12,7 @@
 	</style>
 	<canvas id="canvas"></canvas>
 	<div style="margin-bottom:20px"></div>
-	<div id="reset" onclick="reset()">reset</div>
+	<div id="reset" onclick="reset()">Zurücksetzen</div>
 
 	<script>
 	var TILE_SIZE = 80;


### PR DESCRIPTION
- Use "&hellip;" (the HTML entity/the correct Unicode ellipsis) instead of "..." (the ASCII fallback).
- Add proper spacing around ellipses, see for instance Wikipedia.
- Translate "reset" in mini_cooperate.html.
- Attempt to better translate "amount of bias and anti-bias".
